### PR TITLE
Fix tangle-exploter install instead of start

### DIFF
--- a/tutorial-private-tangle.md
+++ b/tutorial-private-tangle.md
@@ -156,7 +156,7 @@ Once we have our Private Tangle up and running, we can install and run a Tangle 
 
 ```console
 cd ../explorer
-tangle-explorer start ../hornet-private-net
+tangle-explorer install ../hornet-private-net
 ```
 
 Automatically the Tangle Explorer will be configured with the parameters of our Private Tangle, and once the docker build process finishes you should find the following additional docker containers up and running:


### PR DESCRIPTION
# Description of change

Private Tangle instruction should be install instead of start

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
